### PR TITLE
Add cursor_blink to control blinking.

### DIFF
--- a/config.h
+++ b/config.h
@@ -15,6 +15,7 @@ static const char *url_regex = "(ftp|http)s?://[-a-zA-Z0-9.?$%&/=_~#.,:;+]*";
 
 static const char *font = "Monospace 9";
 static const long scrollback_lines = 1000;
+static const bool cursor_blink = false;
 
 static const char *foreground_color = "#dcdccc";
 static const char *background_color = "#3f3f3f";

--- a/termite.c
+++ b/termite.c
@@ -224,6 +224,9 @@ int main(int argc, char **argv) {
     vte_terminal_set_visible_bell(VTE_TERMINAL(vte), visible_bell);
     vte_terminal_set_mouse_autohide(VTE_TERMINAL(vte), mouse_autohide);
 
+    if (!cursor_blink)
+        vte_terminal_set_cursor_blink_mode(VTE_TERMINAL(vte), VTE_CURSOR_BLINK_OFF);
+
 #ifdef TRANSPARENCY
     GdkScreen *screen = gtk_widget_get_screen(window);
     GdkColormap *colormap = gdk_screen_get_rgba_colormap(screen);


### PR DESCRIPTION
I find the cursor blinking distracting and `VTE_CURSOR_BLINK_SYSTEM` wasn't doing the trick outside of gnome.
