### PR TITLE
Enable transparency support for Gtk3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PREFIX = /usr/local
 ifeq (${GTK3}, 1)
 	GTK = gtk+-3.0
 	VTE = vte-2.90
+	CFLAGS += -DGTK3
 else
 	GTK = gtk+-2.0
 	VTE = vte

--- a/termite.c
+++ b/termite.c
@@ -226,11 +226,20 @@ int main(int argc, char **argv) {
 
 #ifdef TRANSPARENCY
     GdkScreen *screen = gtk_widget_get_screen(window);
+
+#ifdef GTK3
     GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
     if (visual == NULL)
         visual = gdk_screen_get_system_visual(screen);
 
     gtk_widget_set_visual(GTK_WIDGET(window), visual);
+#else
+    GdkColormap *colormap = gdk_screen_get_rgba_colormap(screen);
+    if (colormap != NULL) {
+        gtk_widget_set_colormap(window, colormap);
+    }
+#endif
+
     vte_terminal_set_background_saturation(VTE_TERMINAL(vte), TRANSPARENCY);
     vte_terminal_set_opacity(VTE_TERMINAL(vte), (guint16)(0xffff * (1 - TRANSPARENCY)));
 #endif


### PR DESCRIPTION
Okay, this patch is kinda nasty since it adds `#ifdef` / `#else` / `#endif`, but currently transparency is broken for the Gtk3 build.

```
termite.c: In function ‘main’:
termite.c:235:5: error: unknown type name ‘GdkColormap’
termite.c:235:5: warning: implicit declaration of function ‘gdk_screen_get_rgba_colormap’ [-Wimplicit-function-declaration]
termite.c:235:29: warning: initialization makes pointer from integer without a cast [enabled by default]
termite.c:237:9: warning: implicit declaration of function ‘gtk_widget_set_colormap’ [-Wimplicit-function-declaration]
```

The GDK colormap stuff you're using is deprecated and was removed from Gtk3. According to the [Gtk3 docs](http://developer.gnome.org/gtk3/3.0/gtk-question-index.html), this is how its properly supposed to be done. However while this builds on Gtk2, it doesn't enable the transparency and thus I kept your original code in. I'm not sure what approach you'll want to take, I set it to conditionally compile the right version.

Maybe if you're uncomfortable with the conditional only support transparency in the Gtk3 version? Its were upstream is and the `gdk_screen_get_rgba_visual` stuff will compile on Gtk2 without any effects.
