### PR TITLE
Improved scrollback completion

### DIFF
--- a/termite.c
+++ b/termite.c
@@ -107,7 +107,7 @@ static gboolean entry_key_press_cb(GtkEntry *entry, GdkEventKey *event, search_p
                 search(VTE_TERMINAL(info->vte), text, true);
                 break;
             case OVERLAY_COMPLETION:
-                vte_terminal_feed(VTE_TERMINAL(info->vte), text, -1);
+                vte_terminal_feed_child(VTE_TERMINAL(info->vte), text, -1);
                 break;
             case OVERLAY_HIDDEN:
                 break;
@@ -135,6 +135,8 @@ static void overlay_show(search_panel_info *info, enum overlay_mode mode, bool c
 
         gtk_entry_completion_set_text_column(completion, 0);
     }
+
+    gtk_entry_set_text(GTK_ENTRY(info->entry), "");
 
     info->mode = mode;
     gtk_widget_show(GTK_WIDGET(info->panel));


### PR DESCRIPTION
I improved the scrollback completion and embedded it into the overlay search box. I also implemented the logic needed to "simulate" the input to the Vte.

As a bonus, the search function also gets completion. This was unintentional but interesting enough that I let it be. It should be trivial to disable.

Maybe the completion popup delay should be configurable and the default value decreased?
#### Known issues:
- The down key doesn't pop up the completion, it gives focus back to the
  terminal.
- The enter key does not select an item from the drop down list, it
  closes the entry and accepts the input as is.
- ~~Simulated input is permanent and can't be removed.~~
