### PR TITLE
Improved scrollback completion

### DIFF
--- a/termite.c
+++ b/termite.c
@@ -72,8 +72,6 @@ static GtkTreeModel *create_completion_model(VteTerminal *vte) {
     }
 
     g_tree_foreach(tree, (GTraverseFunc)add_to_list_store, store);
-    g_tree_destroy(tree);
-    g_free(content);
 
     return GTK_TREE_MODEL(store);
 }
@@ -108,7 +106,7 @@ static gboolean entry_key_press_cb(GtkEntry *entry, GdkEventKey *event, search_p
                 search(VTE_TERMINAL(info->vte), text, true);
                 break;
             case OVERLAY_COMPLETION:
-                vte_terminal_feed(VTE_TERMINAL(info->vte), text, -1);
+                vte_terminal_feed_child(VTE_TERMINAL(info->vte), text, -1);
                 break;
             case OVERLAY_HIDDEN:
                 break;
@@ -136,6 +134,8 @@ static void overlay_show(search_panel_info *info, enum overlay_mode mode, bool c
 
         gtk_entry_completion_set_text_column(completion, 0);
     }
+
+    gtk_entry_set_text(GTK_ENTRY(info->entry), "");
 
     info->mode = mode;
     gtk_widget_show(GTK_WIDGET(info->panel));


### PR DESCRIPTION
I improved the scrollback completion and embedded it into the overlay search box. I also implemented the logic needed to "simulate" the input to the Vte.

As a bonus, the search function also gets completion. This was unintentional but interesting enough that I let it be. It should be trivial to disable.

Maybe the completion popup delay should be configurable and the default value decreased?
#### Known issues:
- The down key doesn't pop up the completion, it gives focus back to the
  terminal.
- The enter key does not select an item from the drop down list, it
  closes the entry and accepts the input as is.
- ~~Simulated input is permanent and can't be removed.~~ Using vte_terminal_feed_child fixed the permanence issue.

Outside the fact that its cumbersome to use due to the detailed issues, it works perfectly.

Once again, sorry for the noise, I thought I was working on a different branch. I really need a better zsh prompt.
