### PR TITLE
URL select mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,23 @@ COMMAND MODE
 | ``-``                    | decrease font size                                        |
 +--------------------------+-----------------------------------------------------------+
 
+URL SELECT MODE
+---------------
+
++----------------------+-------------------------------------------------------+
+| ``ctrl-shift-z``     | enter url select mode                                 |  
++----------------------+-------------------------------------------------------+
+| ``ctrl-shift-y``     | copy currently select url to CLIPBOARD                |
++----------------------+-------------------------------------------------------+
+| ``ctrl-shift-o``     | open the currently select url                         |
++----------------------+-------------------------------------------------------+
+| ``Return``           | open the currently selected url and exit command mode |
++----------------------+-------------------------------------------------------+
+| ``j``                | forward url search                                    |
++----------------------+-------------------------------------------------------+
+| ``k``                | reverse url search                                    |
++----------------------+-------------------------------------------------------+
+
 During scrollback search, the current selection is changed to the search match
 and copied to the PRIMARY clipboard buffer.
 

--- a/termite.cc
+++ b/termite.cc
@@ -580,6 +580,8 @@ gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) 
                 break;
             case GDK_KEY_Return:
                 open_selection(info->config.browser, vte);
+                /* fall through */
+            case GDK_KEY_Escape:
                 exit_urlselect_mode(vte, &info->select);
                 break;
         }


### PR DESCRIPTION
I've coded up a dedicated url select mode with vi-like keybindings (behaves similarly to u/U in command mode, but with additional commands). I think this would be useful for opening more than one URL at a time, for quickly copying the URL to the clipboard, or quickly opening the latest displayed URL (since it automatically selects it once you enter the mode). I'm also coming from urxvt and I'm too used to this not to have it, but I thought I'd open a pull request since it would be nice to have it in the official version.

The URL hints mode is nice and complementary to this, but I think it's a bit cumbersome to use for these cases, particularly because you can't copy from it nor select URLs which have rolled off the screen. The reasoning for having this in addition to the existing command mode stuff is so we can reuse j/k keys for movement (which is more convenient that having to shift-u) and so additional features (if any) can be added later on without conflicting with command mode keys.

Regarding the implementation itself, I'm not too sure this should be under vi_mode, but since overlay_mode is even more wrong, I put under vi_mode. Also, the actual keybindings I used are not that important, since I'm hoping we'll eventually have customizable keybindings. :D

Would you consider including something like this?
