### PR TITLE
Quick URL selection in the urlselection overlay

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -69,7 +69,7 @@ struct hint_info {
 struct config_info {
     hint_info hints;
     char *browser;
-    gboolean dynamic_title, urgent_on_bell, clickable_url;
+    gboolean dynamic_title, urgent_on_bell, clickable_url, quick_url;
     int tag;
     char *config_file;
 };
@@ -756,7 +756,7 @@ gboolean entry_key_press_cb(GtkEntry *entry, GdkEventKey *event, keybind_info *i
         case GDK_KEY_7:
         case GDK_KEY_8:
         case GDK_KEY_9:
-            if(info->panel.mode == overlay_mode::urlselect)
+            if(info->panel.mode == overlay_mode::urlselect && info->config.quick_url)
             {
                 const char *const text = gtk_entry_get_text(entry);
                 char* fulltext = g_strndup(text, strlen(text)+1);
@@ -1125,6 +1125,7 @@ static void set_config(GtkWindow *window, VteTerminal *vte, config_info *info,
     info->dynamic_title = cfg_bool("dynamic_title", TRUE);
     info->urgent_on_bell = cfg_bool("urgent_on_bell", TRUE);
     info->clickable_url = cfg_bool("clickable_url", TRUE);
+    info->quick_url = cfg_bool("quick_url", FALSE);
 
     if (info->clickable_url) {
         info->tag =
@@ -1305,7 +1306,7 @@ int main(int argc, char **argv) {
          std::vector<url_data>()},
         {vi_mode::insert, 0, 0, 0, 0},
         {{nullptr, nullptr, nullptr, nullptr, 0, 0, 0},
-         nullptr, FALSE, FALSE, FALSE, -1, config_file}
+         nullptr, FALSE, FALSE, FALSE, FALSE, -1, config_file}
     };
 
     load_config(GTK_WINDOW(window), vte, &info.config, &geometry);


### PR DESCRIPTION
This is a quick and simple hack in order to make url selection a bit more intuitive and easy.
Instead of having to hit enter, if the amount of numbers you've entered shares the same amount of digits as the largest link number, it will automatically be opened.

The addition defaults to off, in order to turn it on you need to add "quick_url=true" to your config file.

Any comments are obviously appreciated.
