### PR TITLE
Change term[] to xterm rather than xterm-termite

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1208,7 +1208,7 @@ static void exit_with_status(VteTerminal *vte) {
 
 int main(int argc, char **argv) {
     GError *error = NULL;
-    const char *const term = "xterm-termite";
+    const char *const term = "xterm";
     char *directory = nullptr;
     gboolean version = FALSE, hold = FALSE;
 


### PR DESCRIPTION
TMUX and friends seem to get very agitated when termite claims to be something original rather than xterm, gnome-terminal claims to be xterm, so I think this is more sensible than breaking the everything by default.
