### PR TITLE
Make only possible hints visible

### DIFF
--- a/config
+++ b/config
@@ -32,6 +32,9 @@ cursor_shape = block
 # (default if unset: all graphic non-punctuation/space characters)
 #word_chars = -A-Za-z0-9,./?%&#:_=+@~
 
+# Hide links that are no longer valid in url select overlay mode
+filter_unmatched_urls = true
+
 [colors]
 foreground = #dcdccc
 foreground_bold = #ffffff


### PR DESCRIPTION
This patch is really a one liner that adds a check to see
if there is any input, and if there is only draw the possible
markers and nothing else. Everything added under GDK_KEY_Backspace
is to delete previous entries and probably should have been added
a while ago.