### PR TITLE
Add option to enable size hints for the window

### DIFF
--- a/config
+++ b/config
@@ -32,6 +32,9 @@ cursor_shape = block
 # (default if unset: all graphic non-punctuation/space characters)
 #word_chars = -A-Za-z0-9,./?%&#:_=+@~
 
+# set size hints for the window
+set_size_hints = false
+
 [colors]
 foreground = #dcdccc
 foreground_bold = #ffffff


### PR DESCRIPTION
Adds an option to turn on window size hints so that there isn't any gap on bottom and right sides

I haven't done much C and even less GTK+, but the feature seems to be working correctly.

Thanks!
