### PR TITLE
Use proper comment string in vim's modeline

### DIFF
--- a/config
+++ b/config
@@ -68,4 +68,4 @@ color15 = #ffffff
 #border_width = 0.5
 #roundness = 2.0
 
-# vim: ft=dosini
+# vim: ft=dosini cms=#%s


### PR DESCRIPTION
The dosini format's comment string is normally _;_. In order to allow
vim plugins similar to _commentary_ to work, we need to set it to _#_.
