### PR TITLE
Copy URI to XA_CLIPBOARD on right click

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -924,6 +924,10 @@ gboolean button_press_cb(VteTerminal *vte, GdkEventButton *event, const config_i
             g_free(match);
             return TRUE;
         }
+        else if(event->button == 3 && event->type == GDK_BUTTON_PRESS && match) {
+            GtkClipboard *clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+            gtk_clipboard_set_text(clipboard, match, -1);
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
Small patch that copies the match into the default clipboard using
gtk_clipboard_set_text(). Maybe consider which clipboard to use
(such as PRIMARY OR SECONDARY) instead based on a config option, although
that may be overkill (especially since PRIMARY is supposed to be ephemeral
or something)

This closes #149
