### PR TITLE
produce escape sequences for extra Ctrl- modified keys

### DIFF
--- a/config
+++ b/config
@@ -31,6 +31,9 @@ cursor_shape = block
 # set size hints for the window
 #size_hints = false
 
+# emit escape sequences for other keys modified by Control
+#modify_other_keys = false
+
 [colors]
 foreground = #dcdccc
 foreground_bold = #ffffff

--- a/termite.cc
+++ b/termite.cc
@@ -88,7 +88,7 @@ struct hint_info {
 struct config_info {
     hint_info hints;
     char *browser;
-    gboolean dynamic_title, urgent_on_bell, clickable_url, size_hints;
+    gboolean dynamic_title, urgent_on_bell, clickable_url, size_hints, modify_other_keys;
     int tag;
     char *config_file;
 };
@@ -160,12 +160,14 @@ static const std::map<int, const char *> modify_table = {
 };
 
 static gboolean modify_key_feed(GdkEventKey *event, keybind_info *info) {
-    unsigned int keyval = gdk_keyval_to_lower(event->keyval);
-    auto entry = modify_table.find((int)keyval);
+    if (info->config.modify_other_keys) {
+        unsigned int keyval = gdk_keyval_to_lower(event->keyval);
+        auto entry = modify_table.find((int)keyval);
 
-    if (entry != modify_table.end()) {
-        vte_terminal_feed_child(info->vte, entry->second, -1);
-        return TRUE;
+        if (entry != modify_table.end()) {
+            vte_terminal_feed_child(info->vte, entry->second, -1);
+            return TRUE;
+        }
     }
     return FALSE;
 }
@@ -1263,6 +1265,7 @@ static void set_config(GtkWindow *window, VteTerminal *vte, config_info *info,
     info->urgent_on_bell = cfg_bool("urgent_on_bell", TRUE);
     info->clickable_url = cfg_bool("clickable_url", TRUE);
     info->size_hints = cfg_bool("size_hints", FALSE);
+    info->modify_other_keys = cfg_bool("modify_other_keys", FALSE);
 
     g_free(info->browser);
     info->browser = nullptr;
@@ -1440,7 +1443,7 @@ int main(int argc, char **argv) {
          nullptr},
         {vi_mode::insert, 0, 0, 0, 0},
         {{nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, 0, 0},
-         nullptr, FALSE, FALSE, FALSE, FALSE, -1, config_file},
+         nullptr, FALSE, FALSE, FALSE, FALSE, FALSE, -1, config_file},
         gtk_window_fullscreen
     };
 


### PR DESCRIPTION
This is just for Ctrl- modified keys according to #157.  Adding other Shift-/Meta- combinations in the same fashion would require separate tables, and then perhaps `modify_key_feed` would have to be told which table to use. Also `GDK_META_MASK` would be introduced somewhere.

Thanks to @vodik for help in implementing this.
