### PR TITLE
Add support for alpha channel to the window

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1420,6 +1420,12 @@ int main(int argc, char **argv) {
     GtkWidget *vte_widget = vte_terminal_new();
     VteTerminal *vte = VTE_TERMINAL(vte_widget);
 
+    GdkScreen *screen = gtk_widget_get_screen(window);
+    GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+    if (visual) {
+        gtk_widget_set_visual(GTK_WIDGET(window), visual);
+    }
+
     if (role) {
         gtk_window_set_role(GTK_WINDOW(window), role);
         g_free(role);


### PR DESCRIPTION
Getting the screen's visual and setting it on the window is all that's
needed for VTE's alpha channel support.

Fix #191
