### PR TITLE
Specify proper vte version in .ycm_extra_conf.py

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -37,7 +37,7 @@ flags = [
 ]
 
 flags += pkg_config('gtk+-3.0')
-flags += pkg_config('vte-2.90')
+flags += pkg_config('vte-2.91')
 
 
 def DirectoryOfThisScript():


### PR DESCRIPTION
The dependency was changed in the Makefile but .ycm_extra_conf.py wasn't updated accordingly.