### PR TITLE
Set color palette size to 256

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1188,7 +1188,7 @@ get_config_cairo_color(GKeyFile *config, const char *group, const char *key) {
 }
 
 static void load_theme(GtkWindow *window, VteTerminal *vte, GKeyFile *config, hint_info &hints) {
-    std::array<GdkRGBA, 255> palette;
+    std::array<GdkRGBA, 256> palette;
     char color_key[] = "color000";
 
     for (unsigned i = 0; i < palette.size(); i++) {


### PR DESCRIPTION
Regarding updating to vte 0.40.0, vte now makes the following assertion:
```
(termite:8742): Vte-CRITICAL **: vte_terminal_set_colors: assertion '(palette_size == 0) || (palette_size == 8) || (palette_size == 16) || (palette_size == 232) || (palette_size == 256)' failed
```
and colors will be basically broken without the following change.  I think this should have been 256 anyways.