### PR TITLE
Modify URLPATH to not including "!'(),"

### DIFF
--- a/url_regex.hh
+++ b/url_regex.hh
@@ -9,7 +9,7 @@
 #define PORT            "(?:\\:[[:digit:]]{1,5})?"
 #define SCHEME          "(?:[[:alpha:]][+-.[:alnum:]]*:)"
 #define USERPASS        USERCHARS_CLASS "+(?:" PASSCHARS_CLASS "+)?"
-#define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*)?"
+#define URLPATH         "(?:/[[:alnum:]\\Q-_.~*/?:@&=+$#%\\E]*)?"
 
 const char * const url_regex = SCHEME "//(?:" USERPASS "\\@)?" HOST PORT URLPATH;
 


### PR DESCRIPTION
In most cases, these characters will not be included in an url,
but offen used as sperators in text.
Removing them will benefit most cases.