### PR TITLE
Unparsed options to termite become argv for child process

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -3,7 +3,7 @@
 termite \- A keyboard-centric VTE-based terminal aimed for use with
 a tiling and/or tabbing enabled window manager.
 .SH SYNOPSIS
-\fBtermite\fP [options]
+\fBtermite\fP [options] [PROGRAM [ARGS ...]]
 .SH DESCRIPTION
 \fBtermite\fP is a GTK-based terminal emulator inteded for use within
 window managers with tiling and/or tabbing support. It provides a fast
@@ -14,8 +14,12 @@ terminal experience and pleasant array of keyboard-centric features.
 Display help message.
 .IP "\fB\-v\fR, \fB\-\-version\fR"
 Display version information.
+.IP "\fI PROGRAM \fB[\fIARGS\fB ...]"
+If present, tell termite to execute \fIPROGRAM\fP rather than the default shell. Any subsequent non-option arguments to termite become arguments to \fIPROGRAM\fP.
+.IP
+Overrides an \fB--exec\fP option (see below).
 .IP "\fB\-e\fR, \fB\-\-exec\fR\fB=\fR\fICOMMAND\fR"
-Tell termite start \fICOMMAND\fP instead of the shell.
+Tell termite to start \fICOMMAND\fP instead of the shell. This option is ignored if \fBPROGRAM\fP is given.
 .IP "\fB\-r\fR, \fB\-\-role\fR\fB=\fR\fIROLE\fR"
 The role to set the termite window to report itself with.
 .IP "\fB\-t\fR, \fB\-\-title\fR\fB=\fR\fITITLE\fR"

--- a/termite.cc
+++ b/termite.cc
@@ -1491,6 +1491,7 @@ int main(int argc, char **argv) {
     GOptionContext *context = g_option_context_new(nullptr);
     char *role = nullptr, *geometry = nullptr, *execute = nullptr, *config_file = nullptr;
     char *title = nullptr;
+    char **command_argv = nullptr;
     const GOptionEntry entries[] = {
         {"version", 'v', 0, G_OPTION_ARG_NONE, &version, "Version info", nullptr},
         {"exec", 'e', 0, G_OPTION_ARG_STRING, &execute, "Command to execute", "COMMAND"},
@@ -1500,6 +1501,8 @@ int main(int argc, char **argv) {
         {"geometry", 0, 0, G_OPTION_ARG_STRING, &geometry, "Window geometry", "GEOMETRY"},
         {"hold", 0, 0, G_OPTION_ARG_NONE, &hold, "Remain open after child process exits", nullptr},
         {"config", 'c', 0, G_OPTION_ARG_STRING, &config_file, "Path of config file", "CONFIG"},
+        {G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &command_argv,
+            "Command with arguments to execute", "[PROGRAM [ARGS ... ]]"},
         {nullptr, 0, 0, G_OPTION_ARG_NONE, nullptr, nullptr, nullptr}
     };
     g_option_context_add_main_entries(context, entries, nullptr);
@@ -1536,10 +1539,11 @@ int main(int argc, char **argv) {
         g_free(role);
     }
 
-    char **command_argv;
-    char *default_argv[2] = {nullptr, nullptr};
+    gboolean free_command_argv = FALSE;
 
-    if (execute) {
+    if (command_argv) {
+        free_command_argv = TRUE;
+    } else if (execute) {
         int argcp;
         char **argvp;
         g_shell_parse_argv(execute, &argcp, &argvp, &error);
@@ -1549,6 +1553,7 @@ int main(int argc, char **argv) {
         }
         command_argv = argvp;
     } else {
+        char *default_argv[2] = {nullptr, nullptr};
         default_argv[0] = get_user_shell_with_fallback();
         command_argv = default_argv;
     }
@@ -1679,6 +1684,9 @@ int main(int argc, char **argv) {
                           (height - padding_top - padding_bottom) / char_height);
 
     g_strfreev(env);
+    if (free_command_argv) {
+        g_strfreev(command_argv);
+    }
 
     gtk_main();
     return EXIT_FAILURE; // child process did not cause termination


### PR DESCRIPTION
This allows execution of arbitrary programs with termite, without having to use quotation with the --exec option 