### PR TITLE
termite.cc@main: add some free calls to free allocated options memory

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1501,8 +1501,11 @@ int main(int argc, char **argv) {
 
     if (!g_option_context_parse(context, &argc, &argv, &error)) {
         g_printerr("option parsing failed: %s\n", error->message);
+        g_clear_error (&error);
         return EXIT_FAILURE;
     }
+
+    g_option_context_free(context);
 
     if (version) {
         g_print("termite %s\n", TERMITE_VERSION);


### PR DESCRIPTION
I ran Valgrind against a debug version of the binary. Starting with a
simple --version, it reported some "definite" leaked memory. I tracked
it down to the options parser. Turns out there are some built-in free
calls that aren't being called.

I'll be looking into the other reports as well so expect a few more pull
requests after this.