### PR TITLE
Add support to set the foreground cursor color

### DIFF
--- a/config
+++ b/config
@@ -33,6 +33,7 @@ filter_unmatched_urls = true
 
 [colors]
 #cursor = #dcdccc
+#cursor_foreground = #dcdccc
 foreground = #dcdccc
 foreground_bold = #ffffff
 background = #3f3f3f

--- a/termite.cc
+++ b/termite.cc
@@ -1296,6 +1296,9 @@ static void load_theme(GtkWindow *window, VteTerminal *vte, GKeyFile *config, hi
     if (auto color = get_config_color(config, "colors", "cursor")) {
         vte_terminal_set_color_cursor(vte, &*color);
     }
+    if (auto color = get_config_color(config, "colors", "cursor_foreground")) {
+        vte_terminal_set_color_cursor_foreground(vte, &*color);
+    }
     if (auto color = get_config_color(config, "colors", "highlight")) {
         vte_terminal_set_color_highlight(vte, &*color);
     }


### PR DESCRIPTION
VTE 0.44.1 supports setting the foregorund color of
the cursor using vte_terminal_set_color_cursor_foreground

Closes: #284