### PR TITLE
Resolve GCC 6.1 warning

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -509,7 +509,7 @@ static void update_scroll(VteTerminal *vte) {
     long cursor_row;
     vte_terminal_get_cursor_position(vte, nullptr, &cursor_row);
 
-    if (cursor_row < scroll_row) {
+    if ( (double)cursor_row < scroll_row) {
         gtk_adjustment_set_value(adjust, (double)cursor_row);
     } else if (cursor_row - n_rows >= (long)scroll_row) {
         gtk_adjustment_set_value(adjust, (double)(cursor_row - n_rows + 1));


### PR DESCRIPTION
GCC 6.1 warns about the comparison between an
long and double, cast the long to a double.