### PR TITLE
Fix exception thrown in .ycm_extra_conf.py

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -8,7 +8,7 @@ database = None
 def pkg_config(pkg):
   def not_whitespace(string):
     return not (string == '' or string == '\n')
-  output = subprocess.check_output(['pkg-config', '--cflags', pkg]).strip()
+  output = subprocess.check_output(['pkg-config', '--cflags', pkg], universal_newlines=True).strip()
   return filter(not_whitespace, output.split(' '))
 
 flags = [


### PR DESCRIPTION
The call to subprocess.check_output returns a bytes instead of a str
object if not called with universal_newlines=True which raises an
exception further on due to mixing of bytes and str.