### PR TITLE
Add vte-ng installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,15 @@ to expose functionality that's not required by GNOME Terminal even if there's
 no extra maintenance (it already exists internally) and no additional backwards
 compatibility hazards.
 
+To install the latest version of the vte-ng dependency from Github, run
+::
+
+    git clone https://github.com/thestinger/vte-ng.git
+    cd vte-ng
+    ./autogen.sh
+    sudo make
+    sudo make install
+
 If no browser is configured and $BROWSER is unset, xdg-open from xdg-utils is
 used as a fallback.
 


### PR DESCRIPTION
I assume that the majority of visitors to this repo are here to download and install termite (which, now that I got it to run, is hands down the most satisfying terminal I've ever used!)

As of now, most people will do what I just did: copy-paste the lines under **BUILDING**, run into #367, read an outdated answer about an old VTE-ng version, gamble on some version of the latter, find out how to compile it (it doesn't even have a `./configure` script, which will throw casual users off) and then hope to get everything working together. So it'd be a more pleasant experience if the full installation instructions were right there.