### PR TITLE
Revert "non us fix" and fix it properly

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -916,6 +916,12 @@ gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) 
     }
     if (modifiers == (GDK_CONTROL_MASK|GDK_SHIFT_MASK)) {
         switch (gdk_keyval_to_lower(event->keyval)) {
+            case GDK_KEY_plus:
+                increase_font_scale(vte);
+                return TRUE;
+            case GDK_KEY_equal:
+                reset_font_scale(vte, info->config.font_scale);
+                return TRUE;
             case GDK_KEY_t:
                 launch_in_directory(vte);
                 return TRUE;
@@ -943,14 +949,12 @@ gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) 
                 if (modify_key_feed(event, info, modify_table))
                     return TRUE;
         }
-    }
-    if ((modifiers == (GDK_CONTROL_MASK|GDK_MOD1_MASK)) ||
-           (modifiers == (GDK_CONTROL_MASK|GDK_MOD1_MASK|GDK_SHIFT_MASK))) {
+    } else if ((modifiers == (GDK_CONTROL_MASK|GDK_MOD1_MASK)) ||
+               (modifiers == (GDK_CONTROL_MASK|GDK_MOD1_MASK|GDK_SHIFT_MASK))) {
         if (modify_key_feed(event, info, modify_meta_table))
             return TRUE;
-    }
-    if (modifiers & GDK_CONTROL_MASK) {
-        switch (event->keyval) {
+    } else if (modifiers == GDK_CONTROL_MASK) {
+        switch (gdk_keyval_to_lower(event->keyval)) {
             case GDK_KEY_Tab:
                 overlay_show(&info->panel, overlay_mode::completion, vte);
                 return TRUE;


### PR DESCRIPTION
This reverts commit 305f5cb9381b28740797b646664f2d16ca1f33e8.

The old fix breaks it on US keyboards.  Instead, copy the case down to
be in both ifs.