### PR TITLE
Add BUILDING VTE-NG and TERM info sections to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,30 @@ compatibility hazards.
 If no browser is configured and $BROWSER is unset, xdg-open from xdg-utils is
 used as a fallback.
 
+BUILDING VTE-NG
+---------------
+
+To build vte, you'll need
+
+* gobject-introspection-1.0 (For Debian, this package is named libgirepository1.0-dev)
+* gperf
+* gtk-doc-tools
+* valac
+
+Once dependencies are met, you can build and install by running the following:
+
+::
+
+    git clone https://github.com/thestinger/vte-ng.git
+    cd vte-ng
+    ./autogen.sh
+    ./configure
+    make && make install
+
+If when running termite you get an error about
+``vte_terminal_get_cursor_position``, that indicates that vte-ng isn't
+installed properly yet.
+
 BUILDING
 ========
 ::

--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,6 @@ on any remote servers, the simplest way to add termite's terminfo is to use
 
 ::
 
-    tic termite.terminfo
+    tic -x termite.terminfo
 
 Without this, apps (like tmux) may not run properly.

--- a/README.rst
+++ b/README.rst
@@ -197,3 +197,18 @@ following snippet to ``$XDG_CONFIG_HOME/gtk-3.0/gtk.css`` (or
 
 This can also be used to add varying amounts of padding to each side via
 standard usage of the CSS padding property.
+
+TERMINFO
+========
+
+termite.terminfo is a terminfo entry which defines termite's capabilities to
+libraries such as nvi, rogue, and ncurses, as well as apps that use these
+libraries (like tmux.)
+
+The simplest way to add termite's terminfo to your system is to use ``tic``:
+
+::
+
+    tic termite.terminfo
+
+Without this, apps (like tmux) may not run properly.

--- a/README.rst
+++ b/README.rst
@@ -203,9 +203,10 @@ TERMINFO
 
 termite.terminfo is a terminfo entry which defines termite's capabilities to
 libraries such as nvi, rogue, and ncurses, as well as apps that use these
-libraries (like tmux.)
-
-The simplest way to add termite's terminfo to your system is to use ``tic``:
+libraries (like tmux.) If you installed termite via `make install`, this was
+done for you on your local system. If you need to do this manually or do it
+on any remote servers, the simplest way to add termite's terminfo is to use
+``tic``:
 
 ::
 


### PR DESCRIPTION
While building vte is more documenting how [gnome/vte](https://github.com/gnome/vte) is built, [gnome/vte](https://github.com/gnome/vte) is rarely built separately. Further, rather than adding this to the documentation for [thestinger/vte-ng](https://github.com/thestinger/vte-ng), it make more sense to me to include the documentation here so that [thestinger/vte-ng](https://github.com/thestinger/vte-ng) could stay as close as possible to [gnome/vte](https://github.com/gnome/vte).

Second, it's very handy that you've provided `termite.terminfo`, but many users may not have had to work with terminfo before - especially with so many other terminal emulators simply using `xterm-256color` or some other generic $TERM.
