### PR TITLE
Bugfix for b and B in visual mode

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -587,6 +587,7 @@ static void move_backward(VteTerminal *vte, select_info *select, F is_word) {
     bool in_word = false;
 
     for (long i = length - 2; i > 0; i--) {
+        cursor_col--;
         if (!is_word(codepoints[i - 1])) {
             if (in_word) {
                 break;
@@ -594,7 +595,6 @@ static void move_backward(VteTerminal *vte, select_info *select, F is_word) {
         } else {
             in_word = true;
         }
-        cursor_col--;
     }
     vte_terminal_set_cursor_position(vte, cursor_col, cursor_row);
     update_selection(vte, select);


### PR DESCRIPTION
Before this fix, in visual mode, `b` and `B` set the curser to the begin of a word + 1 character.