### PR TITLE
improving shell detection

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1480,11 +1480,17 @@ static void exit_with_success(VteTerminal *) {
 }
 
 static char *get_user_shell_with_fallback() {
-    if (const char *env = g_getenv("SHELL"))
-        return g_strdup(env);
+    if (const char *env = g_getenv("SHELL") )
+    {
+        if (!((env != NULL) && (env[0] == '\0')))
+            return g_strdup(env);
+    }
 
     if (char *command = vte_get_user_shell())
-        return command;
+    {
+        if (!((command != NULL) && (command[0] == '\0')))
+           return command;
+    }
 
     return g_strdup("/bin/sh");
 }

--- a/termite.cc
+++ b/termite.cc
@@ -1480,14 +1480,12 @@ static void exit_with_success(VteTerminal *) {
 }
 
 static char *get_user_shell_with_fallback() {
-    if (const char *env = g_getenv("SHELL") )
-    {
+    if (const char *env = g_getenv("SHELL") ) {
         if (!((env != NULL) && (env[0] == '\0')))
             return g_strdup(env);
     }
 
-    if (char *command = vte_get_user_shell())
-    {
+    if (char *command = vte_get_user_shell()) {
         if (!((command != NULL) && (command[0] == '\0')))
            return command;
     }


### PR DESCRIPTION
the shell detection might fail with a strange message and to me it was unclear what the problem was. 
The error was something like cannot run "" .
I compiled termite on Ubuntu 16.04, and the user I have tested with did not have an entry for the shell in /etc/passwd. This can happen easily because the adduser command does not add the shell automatically (have not seens this on other Linux flavors so far). Ubuntu  sets the SHELL variable to an empty string. vte_get_user_shell behaves similarly.
I therefore added some simple checks, such that at least the /bin/sh should work.  
 