### PR TITLE
Replace `-e CMD` by positional arguments

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -17,8 +17,6 @@ default shell.
 Display help message.
 .IP "\fB\-v\fR, \fB\-\-version\fR"
 Display version information.
-.IP "\fB\-e\fR, \fB\-\-exec\fR\fB=\fR\fICOMMAND\fR"
-Tell termite start \fICOMMAND\fP instead of the shell.
 .IP "\fB\-r\fR, \fB\-\-role\fR\fB=\fR\fIROLE\fR"
 The role to set the termite window to report itself with.
 .IP "\fB\-t\fR, \fB\-\-title\fR\fB=\fR\fITITLE\fR"

--- a/man/termite.1
+++ b/man/termite.1
@@ -3,12 +3,15 @@
 termite \- A keyboard-centric VTE-based terminal aimed for use with
 a tiling and/or tabbing enabled window manager.
 .SH SYNOPSIS
-\fBtermite\fP [options]
+\fBtermite\fP [options] [--] [COMMAND [ARGS...]]
 .SH DESCRIPTION
 \fBtermite\fP is a GTK-based terminal emulator intended for use within
 window managers with tiling and/or tabbing support. It provides a fast
 terminal experience and pleasant array of keyboard-centric features.
 .SH OPTIONS
+If non-option arguments are given, they specify the name and arguments
+of the command to be executed in the terminal window instead of the
+default shell.
 .PP
 .IP "\fB\-h\fR, \fB\-\-help\fR"
 Display help message.

--- a/termite.cc
+++ b/termite.cc
@@ -1639,6 +1639,7 @@ int main(int argc, char **argv) {
     };
     g_option_context_add_main_entries(context, entries, nullptr);
     g_option_context_add_group(context, gtk_get_option_group(TRUE));
+    g_option_context_set_strict_posix(context, TRUE);
 
     if (!g_option_context_parse(context, &argc, &argv, &error)) {
         g_printerr("option parsing failed: %s\n", error->message);


### PR DESCRIPTION
This implements perfect forwarding of command line arguments as requested in #308 with the solution suggested by you in #310.

Note that it *does* use `G_OPTION_REMAINING` rather than relying on the remaining `argv`. The reason is simplicity: [`g_option_context_parse`](https://developer.gnome.org/glib/stable/glib-Commandline-option-parser.html#g-option-context-parse) does not consistently strip the `--` from `argv` which would require additional post-processing:

> A '--' option is stripped from argv unless there are unparsed options before and after it, or some of the options after it start with '-'.

The patch is mostly adopted from #310 - with one notable exception: use `G_OPTION_ARG_FILENAME_ARRAY` instead of `G_OPTION_ARG_STRING_ARRAY` to prevent decoding and enable perfect forwarding:

> On UNIX systems, the argv that is passed to main() has no particular encoding, even to the extent that different parts of it may have different encodings. In general, normal arguments and flags will be in the current locale and filenames should be considered to be opaque byte strings. Proper use of `G_OPTION_ARG_FILENAME` vs `G_OPTION_ARG_STRING` is therefore important.

(Feel free to cherry-pick any commit even if not accepting the rest)

Best, Thomas