### PR TITLE
Improve URL matching regex

### DIFF
--- a/url_regex.hh
+++ b/url_regex.hh
@@ -3,7 +3,7 @@
 
 #define USERCHARS       "-[:alnum:]"
 #define USERCHARS_CLASS "[" USERCHARS "]"
-#define PASSCHARS_CLASS "[-[:alnum:]\\Q,?;.:/!%$^*&~\"#'\\E]"
+#define PASSCHARS_CLASS "[-[:alnum:]\\Q,?;.!%$^*&~\"#'\\E]"
 #define HOSTCHARS_CLASS "[-[:alnum:]]"
 #define HOST            "(?:" HOSTCHARS_CLASS "+(\\." HOSTCHARS_CLASS "+)*)?"
 #define PORT            "(?:\\:[[:digit:]]{1,5})?"

--- a/url_regex.hh
+++ b/url_regex.hh
@@ -8,7 +8,7 @@
 #define HOST            "(?:" HOSTCHARS_CLASS "+(\\." HOSTCHARS_CLASS "+)*)?"
 #define PORT            "(?:\\:[[:digit:]]{1,5})?"
 #define SCHEME          "(?:[[:alpha:]][+-.[:alnum:]]*:)"
-#define USERPASS        USERCHARS_CLASS "+(?:" PASSCHARS_CLASS "+)?"
+#define USERPASS        USERCHARS_CLASS "+(?:\\:" PASSCHARS_CLASS "+)?"
 #define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*)?"
 
 const char * const url_regex = SCHEME "//(?:" USERPASS "\\@)?" HOST PORT URLPATH;


### PR DESCRIPTION
Made some minor changes that should be spec compliant (to [RFC 1738](https://www.ietf.org/rfc/rfc1738.txt)). The thing that confused me the most (in `url_regex.hh`) was `host` being optional, is there a good reason for that?

Somewhat relevant issue: #155