### PR TITLE
 Clarify xterm-termite fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,3 @@
-
 A keyboard-centric VTE-based terminal, aimed at use within a window manager
 with tiling and/or tabbing support.
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+
 A keyboard-centric VTE-based terminal, aimed at use within a window manager
 with tiling and/or tabbing support.
 
@@ -188,11 +189,21 @@ occur:
 
     Error opening terminal: xterm-termite
 
-To solve this issue, copy the terminfo to your remote system and install it for
-the logged in user. Or on Arch Linux install ``termite-terminfo``.
+This means the remote system needs the `terminfo <https://raw.githubusercontent.com/thestinger/termite/master/termite.terminfo>`_
+file installed. It can be installed either system-wide _or for your local user_;
+you do not need to be root to solve this issue.
 
 ::
 
-    scp termite.terminfo remoteserver:
     # On the remote server
-    tic -x termite.terminfo
+    wget https://raw.githubusercontent.com/thestinger/termite/master/termite.terminfo
+    sudo tic -x termite.terminfo     # this should create /usr/share/terminfo/x/xterm-termite
+    # *or* do this
+    tic -x termite.terminfo     # this should create ~/.terminfo/x/xterm-termite
+
+Or Arch Linux you can just
+
+::
+
+    # On the remote server
+    pacman -S termite-terminfo  # this creates /usr/share/terminfo/x/xterm-termite


### PR DESCRIPTION
This is an update to #468 to complete the instructions. I tried to go looking for termite.terminfo on my system, and didn't immediately realize that the instructions meant I had to go looking in the github repo. I think this info should be worked into the manpage (and maybe termite.terminfo included in packages), next to the instruction about `__vte_prompt_command` which is necessary to make ctrl-shift-t work.

#459, #458, #416, [#364](https://github.com/thestinger/termite/issues/364#issuecomment-288251611), [#305](https://github.com/thestinger/termite/pull/305#issuecomment-183763701), #264 show that this is a common stumbling block in the way of people using termite, which is too bad because it's a slick and sweet piece of tasty software.