### PR TITLE
Fix order of arguments in tic command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install: termite termite.desktop termite.terminfo
 	install -Dm644 termite.desktop ${DESTDIR}${PREFIX}/share/applications/termite.desktop
 	install -Dm644 man/termite.1 ${DESTDIR}${PREFIX}/share/man/man1/termite.1
 	install -Dm644 man/termite.config.5 ${DESTDIR}${PREFIX}/share/man/man5/termite.config.5
-	tic -x termite.terminfo -o ${DESTDIR}${TERMINFO}
+	tic -x -o ${DESTDIR}${TERMINFO} termite.terminfo
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/termite


### PR DESCRIPTION
hanetzer in #gentoo-chat on freenode reported errors like this when building
termite:

    tic -x termite.terminfo -o /tmp/portage/x11-terms/termite-9999/image//usr/share/terminfo
    tic: Too many file names.  Usage:
        tic [-e names] [-o dir] [-R name] [-v[n]] [-V] [-w[n]] [-1aCDcfGgIKLNrsTtUx] source-file

Moving the input filename to the end of the tic invocation seems to resolve
this for them, but I am unable to reproduce the issue.