### PR TITLE
Add optional scrollbar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,13 +167,13 @@ unique match.
 PADDING
 =======
 
-Internal padding can be added by using CSS to style the VTE widget. Adding the
-following snippet to ``$XDG_CONFIG_HOME/gtk-3.0/gtk.css`` (or
+Internal padding can be added by using CSS to style Termite. Adding
+the following snippet to ``$XDG_CONFIG_HOME/gtk-3.0/gtk.css`` (or
 ``~/.config/gtk-3.0/gtk.css``) will add uniform 2px padding around the edges:
 
 .. code:: css
 
-    VteTerminal, vte-terminal {
+    .termite {
         padding: 2px;
     }
 

--- a/config
+++ b/config
@@ -34,6 +34,9 @@ scrollback_lines = 10000
 # set size hints for the window
 #size_hints = false
 
+# "off", "left" or "right"
+#scrollbar = off
+
 [colors]
 # If both of these are unset, cursor falls back to the foreground color,
 # and cursor_foreground falls back to the background color.

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -47,6 +47,9 @@ Automatically hide the mouse pointer when you start typing.
 Set the number of lines to limit the terminal's scrollback. Setting
 the number of lines to 0 disables this feature, a negative value makes
 the scrollback "infinite".
+.IP \fIscrollbar\fR
+Specify scrollbar visibility and position. Accepts \fBoff\fR, \fBleft\fR and
+\fBright\fR.
 .IP \fIscroll_on_keystroke\fR
 Scroll to the bottom automatically when a key is pressed.
 .IP \fIscroll_on_output\fR

--- a/termite.cc
+++ b/termite.cc
@@ -1624,6 +1624,7 @@ int main(int argc, char **argv) {
     VteTerminal *vte = VTE_TERMINAL(vte_widget);
 
     GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_style_context_add_class(gtk_widget_get_style_context(hbox),"termite");
     GtkWidget *scrollbar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(vte_widget)));
     gtk_box_pack_start(GTK_BOX(hbox), hint_overlay, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(hbox), scrollbar, FALSE, FALSE, 0);

--- a/termite.cc
+++ b/termite.cc
@@ -160,10 +160,11 @@ static void search(VteTerminal *vte, const char *pattern, bool reverse);
 static void overlay_show(search_panel_info *info, overlay_mode mode, VteTerminal *vte);
 static void get_vte_padding(VteTerminal *vte, int *left, int *top, int *right, int *bottom);
 static char *check_match(VteTerminal *vte, GdkEventButton *event);
-static void load_config(GtkWindow *window, VteTerminal *vte, config_info *info,
-                        char **geometry, char **icon);
-static void set_config(GtkWindow *window, VteTerminal *vte, config_info *info,
-                        char **geometry, char **icon, GKeyFile *config);
+static void load_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar, GtkWidget *hbox,
+                        config_info *info, char **geometry, char **icon, bool *show_scrollbar);
+static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar, GtkWidget *hbox,
+                       config_info *info, char **geometry, char **icon, bool *show_scrollbar,
+                       GKeyFile *config);
 static long first_row(VteTerminal *vte);
 
 static std::function<void ()> reload_config;
@@ -1370,8 +1371,9 @@ static void load_theme(GtkWindow *window, VteTerminal *vte, GKeyFile *config, hi
     hints.roundness = get_config_double(config, "hints", "roundness").get_value_or(1.5);
 }
 
-static void load_config(GtkWindow *window, VteTerminal *vte, config_info *info,
-                        char **geometry, char **icon) {
+static void load_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar,
+                        GtkWidget *hbox, config_info *info, char **geometry, char **icon,
+                        bool *show_scrollbar) {
     const std::string default_path = "/termite/config";
     GKeyFile *config = g_key_file_new();
     GError *error = nullptr;
@@ -1406,13 +1408,14 @@ static void load_config(GtkWindow *window, VteTerminal *vte, config_info *info,
     }
 
     if (loaded) {
-        set_config(window, vte, info, geometry, icon, config);
+        set_config(window, vte, scrollbar, hbox, info, geometry, icon, show_scrollbar, config);
     }
     g_key_file_free(config);
 }
 
-static void set_config(GtkWindow *window, VteTerminal *vte, config_info *info,
-                        char **geometry, char **icon, GKeyFile *config) {
+static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar, GtkWidget *hbox,
+                       config_info *info, char **geometry, char **icon, bool *show_scrollbar_ptr,
+                       GKeyFile *config) {
     if (geometry) {
         if (auto s = get_config_string(config, "options", "geometry")) {
             *geometry = *s;
@@ -1508,6 +1511,27 @@ static void set_config(GtkWindow *window, VteTerminal *vte, config_info *info,
         set_size_hints(GTK_WINDOW(window), vte);
     }
 
+    bool show_scrollbar = false;
+    if (auto s = get_config_string(config, "options", "scrollbar")) {
+        // "off" is implicitly handled by default
+        if (!g_ascii_strcasecmp(*s, "left")) {
+            show_scrollbar = true;
+            gtk_box_reorder_child(GTK_BOX(hbox), scrollbar, 0);
+        } else if (!g_ascii_strcasecmp(*s, "right")) {
+            show_scrollbar = true;
+            gtk_box_reorder_child(GTK_BOX(hbox), scrollbar, -1);
+        }
+        g_free(*s);
+    }
+    if (show_scrollbar) {
+        gtk_widget_show(scrollbar);
+    } else {
+        gtk_widget_hide(scrollbar);
+    }
+    if (show_scrollbar_ptr != nullptr) {
+        *show_scrollbar_ptr = show_scrollbar;
+    }
+
     load_theme(window, vte, config, info->hints);
 }/*}}}*/
 
@@ -1554,6 +1578,7 @@ int main(int argc, char **argv) {
     GOptionContext *context = g_option_context_new(nullptr);
     char *role = nullptr, *geometry = nullptr, *execute = nullptr, *config_file = nullptr;
     char *title = nullptr, *icon = nullptr;
+    bool show_scrollbar = false;
     const GOptionEntry entries[] = {
         {"version", 'v', 0, G_OPTION_ARG_NONE, &version, "Version info", nullptr},
         {"exec", 'e', 0, G_OPTION_ARG_STRING, &execute, "Command to execute", "COMMAND"},
@@ -1598,6 +1623,11 @@ int main(int argc, char **argv) {
     GtkWidget *vte_widget = vte_terminal_new();
     VteTerminal *vte = VTE_TERMINAL(vte_widget);
 
+    GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    GtkWidget *scrollbar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(vte_widget)));
+    gtk_box_pack_start(GTK_BOX(hbox), hint_overlay, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(hbox), scrollbar, FALSE, FALSE, 0);
+
     if (role) {
         gtk_window_set_role(GTK_WINDOW(window), role);
         g_free(role);
@@ -1633,11 +1663,12 @@ int main(int argc, char **argv) {
         gtk_window_fullscreen
     };
 
-    load_config(GTK_WINDOW(window), vte, &info.config, geometry ? nullptr : &geometry,
-                icon ? nullptr : &icon);
+    load_config(GTK_WINDOW(window), vte, scrollbar, hbox, &info.config,
+                geometry ? nullptr : &geometry, icon ? nullptr : &icon, &show_scrollbar);
 
     reload_config = [&]{
-        load_config(GTK_WINDOW(window), vte, &info.config, nullptr, nullptr);
+        load_config(GTK_WINDOW(window), vte, scrollbar, hbox, &info.config,
+                    nullptr, nullptr, nullptr);
     };
     signal(SIGUSR1, [](int){ reload_config(); });
 
@@ -1659,7 +1690,7 @@ int main(int argc, char **argv) {
     gtk_widget_set_halign(info.panel.entry, GTK_ALIGN_START);
     gtk_widget_set_valign(info.panel.entry, GTK_ALIGN_END);
 
-    gtk_container_add(GTK_CONTAINER(panel_overlay), hint_overlay);
+    gtk_container_add(GTK_CONTAINER(panel_overlay), hbox);
     gtk_container_add(GTK_CONTAINER(hint_overlay), vte_widget);
     gtk_container_add(GTK_CONTAINER(window), panel_overlay);
 
@@ -1713,6 +1744,9 @@ int main(int argc, char **argv) {
     gtk_widget_show_all(window);
     gtk_widget_hide(info.panel.entry);
     gtk_widget_hide(info.panel.da);
+    if (!show_scrollbar) {
+        gtk_widget_hide(scrollbar);
+    }
 
     char **env = g_get_environ();
 


### PR DESCRIPTION
Even in the keyboard-centric interface, scrollbar still have indicative purpose:

* indicate current position within scrollback buffer
* indicate total scrollback size relative to visible screen size

Following new options are valid:

```
# disable scrollbar; this is default
scrollbar = off

# place scrollbar on left/right side of the window
scrollbar = left
scrollbar = right
```

-----

Also introduce add `.termite` GTK CSS class to allow padding (see `README.rst`) not just around VTE widget itself, but also scrollbar.