### PR TITLE
Do not match punctuation at the end of URLs

### DIFF
--- a/url_regex.hh
+++ b/url_regex.hh
@@ -9,7 +9,7 @@
 #define PORT            "(?:\\:[[:digit:]]{1,5})?"
 #define SCHEME          "(?:[[:alpha:]][+-.[:alnum:]]*:)"
 #define USERPASS        USERCHARS_CLASS "+(?:" PASSCHARS_CLASS "+)?"
-#define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*)?"
+#define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*(?<![\\Q.,:;()!?\\E]))?"
 
 const char * const url_regex = SCHEME "//(?:" USERPASS "\\@)?" HOST PORT URLPATH;
 


### PR DESCRIPTION
Punctuation at the end of URLs is most likely part of natural language
or markup (for example in Markdown). Do not match it as part of the URL.