### PR TITLE
Consistent use of ${PREFIX} for installation path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ termite: termite.cc url_regex.hh util/clamp.hh util/maybe.hh util/memory.hh
 install: termite termite.desktop termite.terminfo
 	mkdir -p ${DESTDIR}${TERMINFO}
 	install -Dm755 termite ${DESTDIR}${PREFIX}/bin/termite
-	install -Dm644 config ${DESTDIR}/etc/xdg/termite/config
+	install -Dm644 config ${DESTDIR}${PREFIX}/etc/xdg/termite/config
 	install -Dm644 termite.desktop ${DESTDIR}${PREFIX}/share/applications/termite.desktop
 	install -Dm644 man/termite.1 ${DESTDIR}${PREFIX}/share/man/man1/termite.1
 	install -Dm644 man/termite.config.5 ${DESTDIR}${PREFIX}/share/man/man5/termite.config.5


### PR DESCRIPTION
I have submitted an issue with more detail. Refer to that if you would like the long version. Short version is that the omission of `${PREFIX}` in the install directions for `config` broke the installation on my FreeBSD machine. When I added it installation proceeded as normal. Reject this pull request if the omission was intentional. (I can submit installation troubleshooting tips for FreeBSD users if you'd like.)