### PR TITLE
Fix GTK padding CSS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ the following snippet to ``$XDG_CONFIG_HOME/gtk-3.0/gtk.css`` (or
 
 .. code:: css
 
-    .termite {
+    vte-terminal {
         padding: 2px;
     }
 


### PR DESCRIPTION
The Padding does not work with the `.termite` property. With `vte-terminal` it does work tho. Some sources also add `VteTerminal`, but it doesn't seem to be necessary.