### PR TITLE
Set title to passed command when executing with -e

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1760,7 +1760,11 @@ int main(int argc, char **argv) {
     } else {
         g_signal_connect(vte, "window-title-changed", G_CALLBACK(window_title_cb),
                          &info.config.dynamic_title);
-        window_title_cb(vte, &info.config.dynamic_title);
+        if (execute) {
+            gtk_window_set_title(GTK_WINDOW(window), execute);
+        } else {
+            window_title_cb(vte, &info.config.dynamic_title);
+        }
     }
 
     if (geometry) {


### PR DESCRIPTION
Some background: I used to use rxvt-unicode and I have a few CLI commands set up in my window manager to float instead of tile when launched with `urxvt -e $COMMAND`. This was done by checking the X client's title, which I discovered is not set by termite when executing commands in this way.

In order to reproduce: try running `termite` and then running `top`, and compare with running `termite -e top`. In the first scenario the title is set to "top" by bash's escape wizardry, in the second scenario the title remains "termite".

This quick patch sets the title on startup when termite is executed with the `-e` flag, if and only if the title has not been set by the `-t` flag, and it respects any further title change signaled by `vte` after startup.

