### PR TITLE
Handle Ctrl+Shift+C again

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -998,6 +998,7 @@ gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) 
                 overlay_show(&info->panel, overlay_mode::urlselect, nullptr);
                 exit_command_mode(vte, &info->select);
                 return TRUE;
+            case GDK_KEY_c:
 #if VTE_CHECK_VERSION(0, 50, 0)
                 vte_terminal_copy_clipboard_format(vte, VTE_FORMAT_TEXT);
 #else


### PR DESCRIPTION
As described in #561, support of Ctrl+Shift+C was removed in commit https://github.com/thestinger/termite/commit/01bfd9f9ea8d0d05b063bc43a5121860ccc8d8a2. This PR brings it back. 

Tested with VTE 0.48.2-ng. 