### PR TITLE
Revert "Use std::make_unique from c++14 #360"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GTK = gtk+-3.0
 VTE = vte-2.91
 TERMINFO = ${PREFIX}/share/terminfo
 
-CXXFLAGS := -std=c++14 -O3 \
+CXXFLAGS := -std=c++11 -O3 \
 	    -Wall -Wextra -pedantic \
 	    -Winit-self \
 	    -Wshadow \
@@ -32,7 +32,7 @@ endif
 LDFLAGS := -s -Wl,--as-needed ${LDFLAGS}
 LDLIBS := ${shell pkg-config --libs ${GTK} ${VTE}}
 
-termite: termite.cc url_regex.hh util/clamp.hh util/maybe.hh
+termite: termite.cc url_regex.hh util/clamp.hh util/maybe.hh util/memory.hh
 	${CXX} ${CXXFLAGS} ${LDFLAGS} $< ${LDLIBS} -o $@
 
 install: termite termite.desktop termite.terminfo


### PR DESCRIPTION
This reverts commit 8dd8f55088081965a308ea104bf645a877f12011.

The make_unique function in util/memory.hh is not at all like
std::make_unique. The former is just a plain wrapper for the unique_ptr
constructor and makes the resulting unique_ptr take ownership of the
instance identified by the given pointer.

std::make_unique on the otherhand allocates a new instance of a given
type and makes creates a unique_ptr that has ownership of that instance.

So what the patch did was to allocate a char pointer, that did not
point at the string we're interested in, but instead points at the
pointer that points to that string. This means that the string that was
meant to be freed by the unique_ptr upon leaving its scope leaks.

Additionally, the check in open_selection() wasn't adapted to handle
the extra layer of indirection added by this change, so it always
assumed that there was some selection, and tried to open it, completely
breaking mouse usage.