### PR TITLE
Implement an export insert-mode shortcut

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -62,7 +62,7 @@ enter selection mode
 .IP "\fBctrl-shift-t\fP"
 open a new terminal in the current directory
 .IP "\fBctrl-shift-e\fP"
-export the full contents of the terminal to a "termite.log" file
+export the full contents of the scrollback buffer to a new terminal, using the \fIpager\fP option
 .IP "\fBctrl-shift-up\fP"
 scroll up a line
 .IP "\fBctrl-shift-down\fP"

--- a/man/termite.1
+++ b/man/termite.1
@@ -61,6 +61,8 @@ start scrollback completion
 enter selection mode
 .IP "\fBctrl-shift-t\fP"
 open a new terminal in the current directory
+.IP "\fBctrl-shift-e\fP"
+export the full contents of the terminal to a "termite.log" file
 .IP "\fBctrl-shift-up\fP"
 scroll up a line
 .IP "\fBctrl-shift-down\fP"

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -15,6 +15,9 @@ Have the terminal beep on the terminal bell.
 .IP \fIbrowser\fR
 Set the default browser for opening links. If its not set,
 \fI$BROWSER\fR is read. If that's not set, url hints will be disabled.
+.IP \fIpager\fR
+Set the default pager used when opening the scrollback buffer. If unset,
+\fI$PAGER\fR is read. If that's not set either, \fImore\fP will be used.
 .IP \fIclickable_url\fR
 Auto-detected URLs can be clicked on to open them in your browser. Only
 enabled if a browser is configured or detected.


### PR DESCRIPTION
This commit allows saving the full contents of the terminal (visible
and backlog) to a `termite.log` file using shift+ctrl+e.

Closes #297