### PR TITLE
Implement URL ranges mode

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -47,6 +47,8 @@ within \fBtermite\fP.
 .PP
 .IP "\fBctrl-shift-x\fP"
 activate url hints mode
+.IP "\fBctrl-#\fP"
+activate url ranges hints mode
 .IP "\fBctrl-shift-r\fP"
 reload configuration file
 .IP "\fBctrl-shift-c\fP"
@@ -87,6 +89,8 @@ programs.
 enter insert mode
 .IP "\fBx\fP"
 activate url hints mode
+.IP "\fB#\fP"
+activate url ranges hints mode
 .IP "\fBv\fP"
 visual mode
 .IP "\fBV\fP"


### PR DESCRIPTION
This commit allows ranges of URLs to be opened in the browser once
the range mode has been entered. Unlike in the regular hint mode,
the query string has to be validated with the return key, and is a
comma separated list of IDs/intervals.

Examples:

* to open URLs 2 and 4: 2,4
* to open URLS 2 to 4: 2-4
* to open URLS 1, and 2 to 4: 1,2-4
* to open all URLS starting with URL 2: 2-
* to open all URLs until URL 4: -4
* to open all URLs: -