### PR TITLE
Use https for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "util"]
 	path = util
-	url = git://github.com/thestinger/util.git
+	url = https://github.com/thestinger/util.git


### PR DESCRIPTION
This silences a QA warning on Gentoo and should reduce the risk of MITM
attacks against users.

For reference, this is the Gentoo QA warning:

     * git-r3: git protocol is completely unsecure and may render the ebuild
     * easily susceptible to MITM attacks (even if used only as fallback). Please
     * use https instead.
     * [URI: git://github.com/thestinger/util.git]