### PR TITLE
Use GtkScrolledWindow

### DIFF
--- a/config
+++ b/config
@@ -34,7 +34,7 @@ scrollback_lines = 10000
 # set size hints for the window
 #size_hints = false
 
-# "off", "left" or "right"
+# "off", "left", "right", "overlay_left" or "overlay_right"
 #scrollbar = off
 
 [colors]

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -49,8 +49,8 @@ Set the number of lines to limit the terminal's scrollback. Setting
 the number of lines to 0 disables this feature, a negative value makes
 the scrollback "infinite".
 .IP \fIscrollbar\fR
-Specify scrollbar visibility and position. Accepts \fBoff\fR, \fBleft\fR and
-\fBright\fR.
+Specify scrollbar visibility and position. Accepts \fBoff\fR, \fBleft\fR,
+\fBright\fR, \fBoverlay_left\fR and \fBoverlay_right\fR.
 .IP \fIscroll_on_keystroke\fR
 Scroll to the bottom automatically when a key is pressed.
 .IP \fIscroll_on_output\fR


### PR DESCRIPTION
Instead of adding a GtkScrollbar manually, use a [GtkScrolledWindow](https://developer.gnome.org/gtk3/stable/GtkScrolledWindow.html). This also allows for overlay scrollbars, which combine the convenience of scrollbars with the space savings of no scrollbars.

The overlay scrollbar will take up no space and fade in and out automatically which is particularly useful while working with "full-screen" terminal apps like vi, less or top. If the mouse is moved towards the scrollbar, it grows in size and gets more opaque. The final design is defined by the GTK+ theme, of course.

The config and section 5 man page have been updated accordingly.

Functionality like this has been requested, e.g. in #574

This PR is more a draft. There are some GTK warnings and there is clearly room for improvement. If you consider merging this, feel free to comment.