### PR TITLE
Add bold_is_bright option

### DIFF
--- a/config
+++ b/config
@@ -1,6 +1,7 @@
 [options]
 #allow_bold = true
 #audible_bell = false
+#bold_is_bright = true
 #clickable_url = true
 #dynamic_title = true
 font = Monospace 9

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -12,6 +12,8 @@ Allow the output of bold characters when the bold escape sequence
 appears
 .IP \fIaudible_bell\fR
 Have the terminal beep on the terminal bell.
+.IP \fIbold_is_bright\fR
+Display bold text in bright colors.
 .IP \fIbrowser\fR
 Set the default browser for opening links. If its not set,
 \fI$BROWSER\fR is read. If that's not set, url hints will be disabled.

--- a/termite.cc
+++ b/termite.cc
@@ -1477,6 +1477,9 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
 #if VTE_CHECK_VERSION (0, 49, 1)
     vte_terminal_set_allow_hyperlink(vte, cfg_bool("hyperlinks", FALSE));
 #endif
+#if VTE_CHECK_VERSION (0, 51, 2)
+    vte_terminal_set_bold_is_bright(vte, cfg_bool("bold_is_bright", TRUE));
+#endif
     info->dynamic_title = cfg_bool("dynamic_title", TRUE);
     info->urgent_on_bell = cfg_bool("urgent_on_bell", TRUE);
     info->clickable_url = cfg_bool("clickable_url", TRUE);


### PR DESCRIPTION
#245

Add a `bold_is_bright` option to correspond to [`vte_terminal_set_bold_is_bright`](https://github.com/GNOME/vte/commit/6c44229d130dd1d5cdb218e897ec6f245e96d538).