### PR TITLE
Add cell scaling options

### DIFF
--- a/config
+++ b/config
@@ -7,6 +7,7 @@
 font = Monospace 9
 #fullscreen = true
 #icon_name = terminal
+#line_height_scale = 1.0
 #mouse_autohide = false
 #scroll_on_output = false
 #scroll_on_keystroke = true

--- a/config
+++ b/config
@@ -2,12 +2,13 @@
 #allow_bold = true
 #audible_bell = false
 #bold_is_bright = true
+#cell_height_scale = 1.0
+#cell_width_scale = 1.0
 #clickable_url = true
 #dynamic_title = true
 font = Monospace 9
 #fullscreen = true
 #icon_name = terminal
-#line_height_scale = 1.0
 #mouse_autohide = false
 #scroll_on_output = false
 #scroll_on_keystroke = true

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -41,8 +41,10 @@ The font description for the terminal's font.
 Enables entering fullscreen mode by pressing F11.
 .IP \fIicon_name\fR
 The name of the icon to be used for the terminal process.
-.IP \fIline_height_scale\fR
-Scale the height of lines. Valid values range from 1.0 to 2.0.
+.IP \fIcell_height_scale\fR
+Scale the height of character cells. Valid values range from 1.0 to 2.0.
+.IP \fIcell_width_scale\fR
+Scale the width of character cells. Valid values range from 1.0 to 2.0.
 .IP \fImodify_other_keys\fR
 Emit escape sequences for extra keys, like the \fBmodifyOtherKeys\fR
 resource for \fBxterm\fR(1).

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -41,6 +41,8 @@ The font description for the terminal's font.
 Enables entering fullscreen mode by pressing F11.
 .IP \fIicon_name\fR
 The name of the icon to be used for the terminal process.
+.IP \fIline_height_scale\fR
+Scale the height of lines. Valid values range from 1.0 to 2.0.
 .IP \fImodify_other_keys\fR
 Emit escape sequences for extra keys, like the \fBmodifyOtherKeys\fR
 resource for \fBxterm\fR(1).

--- a/termite.cc
+++ b/termite.cc
@@ -1479,6 +1479,8 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
 #endif
 #if VTE_CHECK_VERSION (0, 51, 2)
     vte_terminal_set_bold_is_bright(vte, cfg_bool("bold_is_bright", TRUE));
+    vte_terminal_set_cell_height_scale(vte, get_config_double(config, "options", "cell_height_scale").get_value_or(1.0));
+    vte_terminal_set_cell_width_scale(vte, get_config_double(config, "options", "cell_width_scale").get_value_or(1.0));
 #endif
     info->dynamic_title = cfg_bool("dynamic_title", TRUE);
     info->urgent_on_bell = cfg_bool("urgent_on_bell", TRUE);
@@ -1521,12 +1523,6 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
         pango_font_description_free(font);
         g_free(*s);
     }
-
-#if VTE_CHECK_VERSION (0, 51, 2)
-    if (auto d = get_config_double(config, "options", "line_height_scale")) {
-        vte_terminal_set_cell_height_scale(vte, *d);
-    }
-#endif
 
     if (auto i = get_config_integer(config, "options", "scrollback_lines")) {
         vte_terminal_set_scrollback_lines(vte, *i);

--- a/termite.cc
+++ b/termite.cc
@@ -1522,6 +1522,12 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
         g_free(*s);
     }
 
+#if VTE_CHECK_VERSION (0, 51, 2)
+    if (auto d = get_config_double(config, "options", "line_height_scale")) {
+        vte_terminal_set_cell_height_scale(vte, *d);
+    }
+#endif
+
     if (auto i = get_config_integer(config, "options", "scrollback_lines")) {
         vte_terminal_set_scrollback_lines(vte, *i);
     }


### PR DESCRIPTION
Add a `line_height_scale` option to correspond to `vte_terminal_set_cell_height_scale` introduced in GNOME/vte@26c79c6.

See issues #209 and #232