### PR TITLE
Ctrl_+ and Ctrl_- with KeyPad, alternative fix

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1028,9 +1028,11 @@ gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) 
                 overlay_show(&info->panel, overlay_mode::completion, vte);
                 return TRUE;
             case GDK_KEY_plus:
+	    case GDK_KEY_KP_Add:
                 increase_font_scale(vte);
                 return TRUE;
             case GDK_KEY_minus:
+	    case GDK_KEY_KP_Subtract:
                 decrease_font_scale(vte);
                 return TRUE;
             case GDK_KEY_equal:


### PR DESCRIPTION
Simple change + "make && sudo make install" seem to work fine on all the systems tested.