### PR TITLE
Only go into fullscreen when F11 is pressed without any modifier

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -809,7 +809,7 @@ gboolean window_state_cb(GtkWindow *, GdkEventWindowState *event, keybind_info *
 gboolean key_press_cb(VteTerminal *vte, GdkEventKey *event, keybind_info *info) {
     const guint modifiers = event->state & gtk_accelerator_get_default_mod_mask();
 
-    if (info->config.fullscreen && event->keyval == GDK_KEY_F11) {
+    if (info->config.fullscreen && event->keyval == GDK_KEY_F11 && !modifiers) {
         info->fullscreen_toggle(info->window);
         return TRUE;
     }


### PR DESCRIPTION
e.g. byobu's tmux keybindings are using Shift-/Ctrl-F11 for some other behaviours