### PR TITLE
Add support for overriding config file.

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -31,6 +31,8 @@ Keep termite open after the child process exits.
 Launch on \fIDISPLAY\fP X display.
 .IP "\fB\-c\fR, \fB\-\-config\fR\fB=\fR\fICONFIG\fR"
 Specify a path to an alternative config file to use.
+.IP "\fB\-C\fR, \fB\-\-exconf\fR\fB=\fR\fICONFIG\fR"
+Loads a secondary config file which can override the default config.
 .PP
 The following two options are built into GTK+ and documented by
 \fB--help-gtk\fR


### PR DESCRIPTION
Allows '-C' flag to specify a config file which should take priority
over already set config. Ideally multiple config files should be able to
be loaded in this way. See this as more of a proof of concept.

I personally wants this to easily switch fonts without copying my whole config.