### PR TITLE
Revert "Document GTK's 'great' emoji input keybinding"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,6 @@ INSERT MODE
 +----------------------+---------------------------------------------+
 | ``ctrl-shift-u``     | unicode input (standard GTK binding)        |
 +----------------------+---------------------------------------------+
-| ``ctrl-shift-e``     | emoji (standard GTK binding)                |
-+----------------------+---------------------------------------------+
 | ``ctrl-tab``         | start scrollback completion                 |
 +----------------------+---------------------------------------------+
 | ``ctrl-shift-space`` | start selection mode                        |

--- a/man/termite.1
+++ b/man/termite.1
@@ -55,8 +55,6 @@ copy to \fICLIPBOARD\fP
 paste from \fICLIPBOARD\fP
 .IP "\fBctrl-shift-u\fP"
 unicode input (standard GTK binding)
-.IP "\fBctrl-shift-e\fP"
-emoji (standard GTK binding)
 .IP "\fBctrl-tab\fP"
 start scrollback completion
 .IP "\fBctrl-shift-space\fP"


### PR DESCRIPTION
This reverts commit db9eb18e97d1400a35515087aff2f5325b9779a7.

> Drop Ctrl-Shift-e shortcut

https://github.com/GNOME/gtk/blob/3.23.0/NEWS#L16