### PR TITLE
2 fixes to backwards-word

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -628,8 +628,8 @@ static void move_backward(VteTerminal *vte, select_info *select, F is_word) {
 
     bool in_word = false;
 
-    for (long i = length - 2; i > 0; i--) {
-        cursor_col--;
+    long i = length - 1;
+    for (; i > 0; i--) {
         if (!is_word(codepoints[i - 1])) {
             if (in_word) {
                 break;
@@ -638,6 +638,7 @@ static void move_backward(VteTerminal *vte, select_info *select, F is_word) {
             in_word = true;
         }
     }
+    cursor_col = std::max<long>(cursor_col - (length - i), 0);
     vte_terminal_set_cursor_position(vte, cursor_col, cursor_row);
     update_selection(vte, select);
 

--- a/termite.cc
+++ b/termite.cc
@@ -626,6 +626,10 @@ static void move_backward(VteTerminal *vte, select_info *select, F is_word) {
         return;
     }
 
+    // sanitize cursor_col, if the user moved the cursor using free movement beyond the end of
+    // the line input the matching be off for one 'word'.
+    cursor_col = length;
+
     bool in_word = false;
 
     long i = length - 1;


### PR DESCRIPTION
Please see individual commits for details.

**NOTE**: I am not sure if the off-by-one is a result of a change in libvte or not. I could not compile libvte versions before 0.54.0 as my system has moved ahead with other libraries and older libvte using deprecated features of those libraries. The incorrect behavior seemed to exist in 0.54.0 as well, and this implementation should fix it for that version as well, based on extremely limited testing. *I mainly tested this against libvte 0.56.3.*

If someone else could test and see that I didn't break older libvte it would be fantastic.