### PR TITLE
Require Control to be pressed to open URLs

### DIFF
--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -18,8 +18,8 @@ Display bold text in bright colors.
 Set the default browser for opening links. If its not set,
 \fI$BROWSER\fR is read. If that's not set, url hints will be disabled.
 .IP \fIclickable_url\fR
-Auto-detected URLs can be clicked on to open them in your browser. Only
-enabled if a browser is configured or detected.
+Auto-detected URLs can be clicked on with Control pressed to open them in your
+browser. Only enabled if a browser is configured or detected.
 .IP \fIhyperlinks\fR
 Enable support for applications to mark text as hyperlinks. Requires
 clickable_url to be set.


### PR DESCRIPTION
>This code keeps track of whether Control is pressed (updated in
>key_press_cb and key_release_cb). Flag is used in button_press_cb.
>
>config_info is not the best place for that flag (by looking at name),
>though, but it is shared between key_press_cb and button_press_cb so it
>was an obvious choice.

Looking for feedback, I am not sure whether it is worth adding a configuration option to switch between old and new behavior.

Closes #525.
 (see https://github.com/thestinger/termite/issues/525#issuecomment-486565092)