### PR TITLE
Improve --exec argument passing

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -16,6 +16,8 @@ Display help message.
 Display version information.
 .IP "\fB\-e\fR, \fB\-\-exec\fR\fB=\fR\fICOMMAND\fR"
 Tell termite start \fICOMMAND\fP instead of the shell.
+.IP "\fB\-x\fR, \fB\-\-greedy\fR"
+Redirect unused termite arguments to exec's \fICOMMAND\fP.
 .IP "\fB\-r\fR, \fB\-\-role\fR\fB=\fR\fIROLE\fR"
 The role to set the termite window to report itself with.
 .IP "\fB\-t\fR, \fB\-\-title\fR\fB=\fR\fITITLE\fR"

--- a/termite.cc
+++ b/termite.cc
@@ -1646,7 +1646,7 @@ int main(int argc, char **argv) {
     gboolean greedy = FALSE;
 
     // Arguments that aren't part of any options
-    gchar **args;
+    gchar **args = nullptr;
 
     GOptionContext *context = g_option_context_new(nullptr);
     char *role = nullptr, *execute = nullptr, *config_file = nullptr;
@@ -1708,8 +1708,8 @@ int main(int argc, char **argv) {
         g_free(role);
     }
 
-    char **command_argv;
-    char *default_argv[] = {nullptr, nullptr};
+    gchar **command_argv;
+    gchar *default_argv[] = {nullptr, nullptr};
 
     if (greedy && !execute) {
         g_printerr("You need to supply a command with -e to redirect arguments.\n");
@@ -1731,7 +1731,6 @@ int main(int argc, char **argv) {
             // Concatenate both arrays of arguments passed to exec
             // and leftover termite arguments
             gchar **total_arguments = (gchar**) g_malloc(sizeof(gchar*) * (leftover_arguments_length + argcp + 1));
-            printf("Total arguments: %d\n", leftover_arguments_length + argcp);
 
             for (int i = 0; i < argcp; i++) {
                 total_arguments[i] = g_strdup(argvp[i]);


### PR DESCRIPTION
Added a new flag, `-x` or `--greedy` to signal that the user wants to redirect unused termite arguments to exec's command.

Usage:
`termite -ex nvim myfile.txt`
`termite -e nvim --greedy myfile1.txt myfile2.txt`
`termite -ex nvim -- -xyz myfile.txt` (`-xyz` will be redirected to nvim, since they are placed after the `--`. If they were placed before, termite would error out claiming to have found a unknown option, which makes sense)