### PR TITLE
Add smart_copy option

### DIFF
--- a/config
+++ b/config
@@ -40,6 +40,11 @@ scrollback_lines = 10000
 # "off", "left" or "right"
 #scrollbar = off
 
+# Enable smart copy. ^C will copy if text has been selected. ^V will paste. It
+# is no longer possible to send a ^V to the running program when this option is
+# enabled.
+#smart_copy = false
+
 [colors]
 # If both of these are unset, cursor falls back to the foreground color,
 # and cursor_foreground falls back to the background color.

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -69,3 +69,7 @@ terminal's cell size. Requires a window manager that respects scroll
 hints.
 .IP \fIurgent_on_bell\fR
 Sets the window as urgent on the terminal bell.
+.IP \fIsmart_copy\fR
+Enable smart copy. \fB^C\fR will copy if text has been selected.
+\fB^V\fR will paste. It is no longer possible to send a \fB^V\fR to the
+running program when this option is enabled.


### PR DESCRIPTION
I'm sorry for creating a PR out of nowhere without consulting you first. Feel free to reject this if you feel like it's out of scope for this project.

---

This has been inspired from the Elementary OS terminal. This option allows the user to copy and paste naturally just like in any other application with minimal feature loss. And, more importantly, reduces the habit where I press `CTRL + SHIFT + C` in my browser and it opens the devtools.

I needed to change the copy behavior so it deselected any selected text after copying. This allows the `CTRL + C`, `CTRL + V` combo to work without having to click on the terminal in between.