### PR TITLE
Added a generic name to the termite.desktop

### DIFF
--- a/termite.desktop
+++ b/termite.desktop
@@ -6,3 +6,4 @@ Icon=utilities-terminal
 Type=Application
 Categories=GTK;System;TerminalEmulator;
 StartupNotify=true
+GenericName=Terminal Emulator


### PR DESCRIPTION
I have added a generic name to the termite.desktop file to show Terminal emulator when hovering over it on desktop environments. You can merge it