### PR TITLE
Adds tabs support via xembedd

### DIFF
--- a/man/termite.1
+++ b/man/termite.1
@@ -23,6 +23,8 @@ Set the termite window's title to \fITITLE\fP. This disables dynamic
 titles.
 .IP "\fB\-d\fR, \fB\-\-directory\fR\fB=\fR\fIDIRECTORY\fR"
 Tell termite to change to \fIDIRECTORY\fP when launching.
+.IP "\fB\-w\fR, \fB\-\-window-id\fR\fB=\fR\fIPARENTWIN\fR"
+Embeds termite within the window identified by \fIPARENTWIN\fP.
 .IP "\fB\-\-icon\fR\f8=\fR\fIICON\fR"
 Override the window icon name.
 .IP "\fB\-\-hold\fR"

--- a/termite.cc
+++ b/termite.cc
@@ -1694,9 +1694,10 @@ int main(int argc, char **argv) {
     GtkWidget *window;
 
 #ifdef GDK_WINDOWING_X11
+    int def_width=800, def_height=600;
     if (embed_id) {
         window = gtk_plug_new (embed_id);
-        gtk_window_set_default_size (GTK_WINDOW (window), 800, 600);
+        gtk_window_set_default_size (GTK_WINDOW (window), def_width, def_height);
     }else
 #endif
         window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -1858,8 +1859,13 @@ int main(int argc, char **argv) {
     int width, height, padding_left, padding_top, padding_right, padding_bottom;
     const long char_width = vte_terminal_get_char_width(vte);
     const long char_height = vte_terminal_get_char_height(vte);
-
-    gtk_window_get_size(GTK_WINDOW(window), &width, &height);
+#ifdef GDK_WINDOWING_X11
+    if(embed_id){
+        width=def_width;
+        height=def_height;
+    }else
+#endif
+        gtk_window_get_size(GTK_WINDOW(window), &width, &height);
     get_vte_padding(vte, &padding_left, &padding_top, &padding_right, &padding_bottom);
     vte_terminal_set_size(vte,
                           (width - padding_left - padding_right) / char_width,

--- a/termite.cc
+++ b/termite.cc
@@ -1694,10 +1694,13 @@ int main(int argc, char **argv) {
     GtkWidget *window;
 
 #ifdef GDK_WINDOWING_X11
-    int def_width=800, def_height=600;
+    int parent_width, parent_height;
     if (embed_id) {
         window = gtk_plug_new (embed_id);
-        gtk_window_set_default_size (GTK_WINDOW (window), def_width, def_height);
+        GdkWindow *gdk_window = gtk_plug_get_socket_window (GTK_PLUG(window));
+        parent_width = gdk_window_get_width (gdk_window);
+        parent_height = gdk_window_get_height (gdk_window);
+        gtk_widget_set_size_request(window, parent_width, parent_height);
     }else
 #endif
         window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -1861,8 +1864,8 @@ int main(int argc, char **argv) {
     const long char_height = vte_terminal_get_char_height(vte);
 #ifdef GDK_WINDOWING_X11
     if(embed_id){
-        width=def_width;
-        height=def_height;
+        width = parent_width;
+        height = parent_height;
     }else
 #endif
         gtk_window_get_size(GTK_WINDOW(window), &width, &height);

--- a/termite.cc
+++ b/termite.cc
@@ -37,6 +37,7 @@
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#include <gtk/gtkx.h>
 #endif
 
 #include "url_regex.hh"
@@ -1642,6 +1643,10 @@ int main(int argc, char **argv) {
     char *directory = nullptr;
     gboolean version = FALSE, hold = FALSE;
 
+#ifdef GDK_WINDOWING_X11
+    gint embed_id = 0;
+#endif
+
     GOptionContext *context = g_option_context_new(nullptr);
     char *role = nullptr, *execute = nullptr, *config_file = nullptr;
     char *title = nullptr, *icon = nullptr;
@@ -1652,6 +1657,11 @@ int main(int argc, char **argv) {
         {"role", 'r', 0, G_OPTION_ARG_STRING, &role, "The role to use", "ROLE"},
         {"title", 't', 0, G_OPTION_ARG_STRING, &title, "Window title", "TITLE"},
         {"directory", 'd', 0, G_OPTION_ARG_STRING, &directory, "Change to directory", "DIRECTORY"},
+
+#ifdef GDK_WINDOWING_X11
+        {"window-id", 'w', 0, G_OPTION_ARG_INT, &embed_id, "embedd termite into window-id", "PARENTWIN"},
+#endif
+
         {"hold", 0, 0, G_OPTION_ARG_NONE, &hold, "Remain open after child process exits", nullptr},
         {"config", 'c', 0, G_OPTION_ARG_STRING, &config_file, "Path of config file", "CONFIG"},
         {"icon", 'i', 0, G_OPTION_ARG_STRING, &icon, "Icon", "ICON"},
@@ -1681,7 +1691,15 @@ int main(int argc, char **argv) {
         g_free(directory);
     }
 
-    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    GtkWidget *window;
+
+#ifdef GDK_WINDOWING_X11
+    if (embed_id) {
+        window = gtk_plug_new (embed_id);
+        gtk_window_set_default_size (GTK_WINDOW (window), 800, 600);
+    }else
+#endif
+        window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
     GtkWidget *panel_overlay = gtk_overlay_new();
     GtkWidget *hint_overlay = gtk_overlay_new();


### PR DESCRIPTION
This adds xembed support which essentially adds tabs to termite via [suckless tabbed ](https://tools.suckless.org/tabbed/). 

This resolves #600 #267 #261 and #439  .. 

This feature is clearly needed by lots of users, and the changes are minimal (20 lines), customized for X11, and configurable via cli option. 

### Running termite with tabbed
1. Install [suckless tabbed ](https://tools.suckless.org/tabbed/):
```
git clone https://git.suckless.org/tabbed && cd tabbed && make && sudo make install
```
2. Run termite with tabbed!
```
tabbed termite -w 
```
3. Checkout tabbed config and docs for keybindings and customization. (defaults: ctrl+shift+enter for new tab, ctrl+shift+(l/h) for switching tabs)

### PoC
![tabbed-termite-poc](https://user-images.githubusercontent.com/37745347/87850212-83458680-c8bc-11ea-8b30-e22bcf513ae6.gif)


### Minimal quirk

1. Although having zero effects during my simple test, this error shows during start up. 
```
(termite:13505): Vte-CRITICAL **: 02:40:18.774: void vte_terminal_set_size(VteTerminal*, long int, long int): assertion 'columns >= 1' failed
```

This really have no affect on usability from what I have seen, please let me know if I am wrong. However, after debugging, it turns out that the dimensions passed to `vte_terminal_set_size` is somehow set to 1*1. I was hoping one of the maintainers would chime in and point out how to fix this. 
