### PR TITLE
Enable vte sixel support

### DIFF
--- a/termite.cc
+++ b/termite.cc
@@ -1500,6 +1500,9 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
     vte_terminal_set_cell_height_scale(vte, get_config_double(config, "options", "cell_height_scale").get_value_or(1.0));
     vte_terminal_set_cell_width_scale(vte, get_config_double(config, "options", "cell_width_scale").get_value_or(1.0));
 #endif
+#if VTE_CHECK_VERSION (0, 61, 90)
+    vte_terminal_set_enable_sixel(vte, cfg_bool("enable_sixel", TRUE));
+#endif
     info->dynamic_title = cfg_bool("dynamic_title", TRUE);
     info->urgent_on_bell = cfg_bool("urgent_on_bell", TRUE);
     info->clickable_url = cfg_bool("clickable_url", TRUE);


### PR DESCRIPTION
Fixes #772.

VTE [added support for sixel](https://gitlab.gnome.org/GNOME/vte/-/issues/253#note_886802) but then [subsequently reverted it](https://gitlab.gnome.org/GNOME/vte/-/commit/b11351e19e61a5bf07ddad6587af24211dd7e63c). However, when removing the support, the public API was left as stubs (and in fact support has since been re-added behind a build flag).  This PR adds a call to enable VTE sixel support (with a new config option `enable_sixel` to disable if desired) which will be a no-op on VTE versions that were built without support but will do the right thing once VTE fully releases support (or when linking against a VTE that was built with the relevant flag).